### PR TITLE
Ensure CommandError handling works

### DIFF
--- a/jacquard/cli.py
+++ b/jacquard/cli.py
@@ -115,7 +115,7 @@ def main(args=sys.argv[1:], config=None):
             options.func(config, options)
         except CommandError as exc:
             (message,) = exc.args
-            sys.stderr.write("%s\n", message)
+            print(message, file=sys.stderr)
             exit(1)
 
 


### PR DESCRIPTION
This fixes an issue where it didn't as it was writing to `stderr` wrongly (`sys.stderr.write` doesn't take two arguments).