### PR TITLE
Don't edit concluded experiments in load-experiment

### DIFF
--- a/jacquard/cli.py
+++ b/jacquard/cli.py
@@ -115,7 +115,7 @@ def main(args=sys.argv[1:], config=None):
             options.func(config, options)
         except CommandError as exc:
             (message,) = exc.args
-            sys.stderr.write("%s\n", message)
+            print(message, file=sys.stderr)
             exit(1)
 
 

--- a/jacquard/experiments/commands.py
+++ b/jacquard/experiments/commands.py
@@ -143,7 +143,7 @@ class Load(BaseCommand):
         parser.add_argument(
             '--skip-launched',
             action='store_true',
-            help="do not error on launched experiments",
+            help="do not load or error on launched experiments",
         )
 
     @retrying

--- a/jacquard/experiments/tests/test_smoke.py
+++ b/jacquard/experiments/tests/test_smoke.py
@@ -1,6 +1,9 @@
+import io
 import datetime
-from unittest.mock import Mock
+import contextlib
+from unittest.mock import Mock, patch
 
+import pytest
 import dateutil.tz
 
 from jacquard.cli import main
@@ -58,3 +61,52 @@ def test_conclude_updates_defaults():
     assert 'concluded' in config.storage['experiments/foo']
     assert 'foo' not in config.storage['active-experiments']
     assert config.storage['defaults'] == BRANCH_SETTINGS
+
+
+def test_load_after_launch_errors():
+    config = Mock()
+    config.storage = DummyStore('', data=DUMMY_DATA_POST_LAUNCH)
+
+    experiment_data = {'id': 'foo'}
+    experiment_data.update(DUMMY_DATA_PRE_LAUNCH['experiments/foo'])
+
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr), pytest.raises(SystemExit):
+        with patch(
+            'jacquard.experiments.commands.yaml.safe_load',
+            return_value=experiment_data,
+        ), patch(
+            'jacquard.experiments.commands.argparse.FileType',
+            return_value=str,
+        ):
+            main(('load-experiment', 'foo.yaml'), config=config)
+
+    stderr_content = stderr.getvalue()
+    assert "Experiment 'foo' is live, refusing to edit" in stderr_content
+
+    fresh_data = DummyStore('', data=DUMMY_DATA_POST_LAUNCH)
+    assert fresh_data.data == config.storage.data, "Data should be unchanged"
+
+
+def test_load_after_launch_with_skip_launched():
+    config = Mock()
+    config.storage = DummyStore('', data=DUMMY_DATA_POST_LAUNCH)
+
+    experiment_data = {'id': 'foo'}
+    experiment_data.update(DUMMY_DATA_PRE_LAUNCH['experiments/foo'])
+
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr), patch(
+        'jacquard.experiments.commands.yaml.safe_load',
+        return_value=experiment_data,
+    ), patch(
+        'jacquard.experiments.commands.argparse.FileType',
+        return_value=str,
+    ):
+        main(('load-experiment', '--skip-launched', 'foo.yaml'), config=config)
+
+    fresh_data = DummyStore('', data=DUMMY_DATA_POST_LAUNCH)
+    assert fresh_data.data == config.storage.data, "Data should be unchanged"
+
+    stderr_content = stderr.getvalue()
+    assert '' == stderr_content


### PR DESCRIPTION
This adds a new storage key which includes all the concluded experiments and a check in `load-experiment` which uses that data to ensure that no changes are made to concluded experiments.

We use the existing `--skip-launched` flag since the intent is the same in both cases (and concluded experiments have technically been launched at some point).

We assume that transactions are atomic to ensure consistency between the existing `active-experiments` and the new `concluded-experiments` keys.

Depends on #55.
Fixes #49.