### PR TITLE
Add type checking with mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ target/
 jacquard.db
 config.cfg
 doc/_build
+.mypy_cache/

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   pre:
-    - pip install pytest pytest-cov fakeredis hypothesis
+    - pip install pytest pytest-cov fakeredis hypothesis mypy
     - pip install -r script/linting/requirements.txt
     - sudo apt-get update ; sudo apt-get install python3 python3-setuptools
     - gem install fpm
@@ -19,6 +19,7 @@ test:
     - mkdir -p $CIRCLE_TEST_REPORTS/pytest
     - py.test -v --cov=jacquard --junit-xml=$CIRCLE_TEST_REPORTS/pytest/junit.xml jacquard
     - script/linting/lint
+    - mypy jacquard --ignore-missing-imports
   post:
     - ./hax_debian.sh
     - mv *.deb $CIRCLE_ARTIFACTS/

--- a/jacquard/storage/cloned_redis.py
+++ b/jacquard/storage/cloned_redis.py
@@ -6,6 +6,7 @@ import pickle
 import logging
 import warnings
 import threading
+from typing import Dict, Any
 
 import redis
 
@@ -15,7 +16,7 @@ from .exceptions import Retry
 LOGGER = logging.getLogger('jacquard.storage.cloned_redis')
 
 
-_REDIS_POOL = {}
+_REDIS_POOL: Dict[str, Any] = {}
 _REDIS_POOL_LOCK = threading.Lock()
 
 


### PR DESCRIPTION
This PR represents the bare minimum required to get type checking running in the CI.

It only adds enough types (only 1 place) to get the type checker passing. Following PRs will add types to more areas of the codebase in order to achieve more safety.

This is only a proposal, I'm happy to discuss the advantages/disadvantages to this, and continue adding types on a separate branch.