### PR TITLE
Commands usability 2

### DIFF
--- a/integration-tests/experiments.yaml
+++ b/integration-tests/experiments.yaml
@@ -3,6 +3,16 @@
 - command: list experiments
   expect: |
     hello: Hello!
+- command: list --detailed
+  expect: |
+    hello: Hello!
+    =============
+
+    Not yet launched
+
+- command: show-experiment hello
+  expect: |
+    hello: Hello!
     =============
 
     Not yet launched

--- a/integration-tests/experiments.yaml
+++ b/integration-tests/experiments.yaml
@@ -3,14 +3,14 @@
 - command: list experiments
   expect: |
     hello: Hello!
-- command: list --detailed
+- command: list experiments --detailed
   expect: |
     hello: Hello!
     =============
 
     Not yet launched
 
-- command: show-experiment hello
+- command: show experiment hello
   expect: |
     hello: Hello!
     =============

--- a/jacquard/experiments/commands.py
+++ b/jacquard/experiments/commands.py
@@ -197,19 +197,40 @@ class ListExperiments(BaseCommand):
         """Run command."""
         with config.storage.transaction(read_only=True) as store:
             for experiment in Experiment.enumerate(store):
-                if experiment.name == experiment.id:
-                    title = experiment.id
-                else:
-                    title = '%s: %s' % (experiment.id, experiment.name)
-                print(title)
-                print('=' * len(title))
-                print()
-                if experiment.launched:
-                    print('Launched: %s' % experiment.launched)
-                    if experiment.concluded:
-                        print('Concluded: %s' % experiment.concluded)
-                    else:
-                        print('In progress')
-                else:
-                    print('Not yet launched')
-                print()
+                Show.show_experiment(experiment)
+
+
+class Show(BaseCommand):
+    """Show a given experiment."""
+
+    help = "show details about an experiment"
+
+    @staticmethod
+    def show_experiment(experiment):
+        """Print information about the given experiment."""
+        if experiment.name == experiment.id:
+            title = experiment.id
+        else:
+            title = '%s: %s' % (experiment.id, experiment.name)
+        print(title)
+        print('=' * len(title))
+        print()
+        if experiment.launched:
+            print('Launched: %s' % experiment.launched)
+            if experiment.concluded:
+                print('Concluded: %s' % experiment.concluded)
+            else:
+                print('In progress')
+        else:
+            print('Not yet launched')
+        print()
+
+    def add_arguments(self, parser):
+        """Add argparse arguments."""
+        parser.add_argument('experiment', help="experiment to show")
+
+    def handle(self, config, options):
+        """Run command."""
+        with config.storage.transaction(read_only=True) as store:
+            experiment = Experiment.from_store(store, options.experiment)
+            self.show_experiment(experiment)

--- a/jacquard/experiments/commands.py
+++ b/jacquard/experiments/commands.py
@@ -193,11 +193,19 @@ class ListExperiments(BaseCommand):
 
     help = "list all experiments"
 
+    def add_arguments(self, parser):
+        """Add argparse arguments."""
+        parser.add_argument(
+            '--detailed',
+            action='store_true',
+            help="whether to show experiment details in the listing",
+        )
+
     def handle(self, config, options):
         """Run command."""
         with config.storage.transaction(read_only=True) as store:
             for experiment in Experiment.enumerate(store):
-                Show.show_experiment(experiment)
+                Show.show_experiment(experiment, options.detailed)
 
 
 class Show(BaseCommand):
@@ -206,24 +214,25 @@ class Show(BaseCommand):
     help = "show details about an experiment"
 
     @staticmethod
-    def show_experiment(experiment):
+    def show_experiment(experiment, detailed=True):
         """Print information about the given experiment."""
         if experiment.name == experiment.id:
             title = experiment.id
         else:
             title = '%s: %s' % (experiment.id, experiment.name)
         print(title)
-        print('=' * len(title))
-        print()
-        if experiment.launched:
-            print('Launched: %s' % experiment.launched)
-            if experiment.concluded:
-                print('Concluded: %s' % experiment.concluded)
+        if detailed:
+            print('=' * len(title))
+            print()
+            if experiment.launched:
+                print('Launched: %s' % experiment.launched)
+                if experiment.concluded:
+                    print('Concluded: %s' % experiment.concluded)
+                else:
+                    print('In progress')
             else:
-                print('In progress')
-        else:
-            print('Not yet launched')
-        print()
+                print('Not yet launched')
+            print()
 
     def add_arguments(self, parser):
         """Add argparse arguments."""

--- a/jacquard/tests/test_integration.py
+++ b/jacquard/tests/test_integration.py
@@ -83,17 +83,21 @@ def test_integration(test_file):
     for step in test_config:
         if 'command' in step:
             stdout = io.StringIO()
+            stderr = io.StringIO()
 
             args = shlex.split(step['command'])
 
             try:
                 with contextlib.redirect_stdout(stdout):
-                    with _temporary_working_directory(JACQUARD_ROOT):
-                        main(args, config=config)
+                    with contextlib.redirect_stderr(stderr):
+                        with _temporary_working_directory(JACQUARD_ROOT):
+                            main(args, config=config)
             except SystemExit:
                 pass
 
             output = stdout.getvalue()
+
+            assert not stderr.getvalue()
 
         elif 'get' in step:
             path = step['get']

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
             'user = jacquard.users.commands:Show',
             'defaults = jacquard.users.commands:Show',
             'directory-entry = jacquard.directory.commands:ShowDirectoryEntry',
+            'experiment = jacquard.experiments.commands:Show',
         ),
         'jacquard.directory_engines': (
             'dummy = jacquard.directory.dummy:DummyDirectory',


### PR DESCRIPTION
This applies the work done in #50 to the current (changed) commands structure:
Add an `experiment` subject to `show` command which prints the detailed output for a single experiment and make `list experiment`'s output shorter by default.