### PR TITLE
Storage flush safety

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -110,13 +110,3 @@ storage-export
    :func: argument_parser
    :prog: jacquard
    :path: storage-export
-
-storage-flush
-~~~~~~~~~~~~~
-
-.. argparse::
-   :module: jacquard.cli
-   :func: argument_parser
-   :prog: jacquard
-   :path: storage-flush
-

--- a/jacquard/storage/commands.py
+++ b/jacquard/storage/commands.py
@@ -87,11 +87,11 @@ class StorageFlush(BaseCommand):
     before imports.
 
     There is an open question as to whether it would be wise to make this the
-    default behaviour of importing, and to hide this command as a plumbing
-    command.
+    default behaviour of importing.
     """
 
     help = "clear everything in storage"
+    plumbing = True
 
     def add_arguments(self, parser):
         """Add argparse arguments."""

--- a/jacquard/storage/commands.py
+++ b/jacquard/storage/commands.py
@@ -89,8 +89,6 @@ class StorageFlush(BaseCommand):
     There is an open question as to whether it would be wise to make this the
     default behaviour of importing, and to hide this command as a plumbing
     command.
-
-    Also some kind of sanity "are you sure" check might be useful.
     """
 
     help = "clear everything in storage"

--- a/jacquard/storage/commands.py
+++ b/jacquard/storage/commands.py
@@ -33,9 +33,6 @@ class StorageImport(BaseCommand):
 
     This is a mechanism to make migrations between storage engines easier,
     when the time comes to upgrade. Also useful for restoring backups.
-
-    Note that this does not flush the current store before importing, it is
-    wise to do so manually.
     """
 
     help = "load stored data from another storage engine"
@@ -44,12 +41,17 @@ class StorageImport(BaseCommand):
         """Add argparse arguments."""
         parser.add_argument('engine', help="storage engine to load from")
         parser.add_argument('url', help="storage URL to load from")
+        parser.add_argument(
+            '--flush',
+            action='store_true',
+            help="flush out the previous data in storage",
+        )
 
     @retrying
     def handle(self, config, option):
         """Run command."""
         src = open_engine(config, option.engine, option.url)
-        copy_data(src, config.storage)
+        copy_data(src, config.storage, flush=option.flush)
 
 
 class StorageExport(BaseCommand):


### PR DESCRIPTION
Rather than encouraging people to use `storage-flush`, we now hide it as a plumbing command and instead offer a `--flush` argument on `storage-import`.

Fixes #70.