### PR TITLE
We actually depend on Werkzeug<1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
 
     install_requires=(
         'redis',
-        'werkzeug',
+        'werkzeug<1',
         'python-dateutil',
         'pyyaml',
         'sqlalchemy',


### PR DESCRIPTION
Specifically: we rely on `werkzeug.config`, which is no longer present in 1.x.